### PR TITLE
Update name of root node on bullet scene

### DIFF
--- a/Teamshootout/Players/bullet.tscn
+++ b/Teamshootout/Players/bullet.tscn
@@ -8,7 +8,7 @@ extents = Vector2( 20, 4.89646 )
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 19.9375, 5.0141 )
 
-[node name="RigidBody2D" type="RigidBody2D"]
+[node name="bullet" type="RigidBody2D"]
 continuous_cd = 2
 can_sleep = false
 


### PR DESCRIPTION
The enemy will only die if the name of the bullet has the string "bul" in its name but the name of the bullets are "RigidBody2D" (the root node of the bullet scene).

You can fix it by naming the root node of the bullet scene "bullet"